### PR TITLE
Fix 1x2 shading rate

### DIFF
--- a/ffx-variableshading/ffx_variable_shading.h
+++ b/ffx-variableshading/ffx_variable_shading.h
@@ -362,7 +362,7 @@ void FFX_VariableShading_GenerateVrsImage(uint3 Gid, uint3 Gtid, uint Gidx)
                 float2 minmax = float2(min(min(lum.x, lum.y), min(lum.z, lum.w)), max(max(lum.x, lum.y), max(lum.z, lum.w)));
                 float3 delta;
                 delta.x = max(abs(lum.x - lum.y), abs(lum.z - lum.w));
-                delta.y = max(abs(lum.x - lum.y), abs(lum.z - lum.w));
+                delta.y = max(abs(lum.x - lum.z), abs(lum.y - lum.w));
                 delta.z = minmax.y - minmax.x;
 
                 // reduce shading rate for fast moving pixels


### PR DESCRIPTION
In the `FFX_VARIABLESHADING_ADDITIONALSHADINGRATES` version, the 1x2 shading rate is calculated using the 2x1 delta. This leads to 1x1 being used instead of 1x2.